### PR TITLE
Fix f-string syntax error

### DIFF
--- a/defunc.py
+++ b/defunc.py
@@ -145,10 +145,10 @@ def config():
             if file.endswith('.session'):
                 sessions.append(file)
 
-        key = str(input((f"1 - Обновить api_id [{options[0].replace('\n', '')}]\n"
-                         f"2 - Обновить api_hash [{options[1].replace('\n', '')}]\n"
-                         f"3 - Парсить user-id [{options[2].replace('\n', '')}]\n"
-                         f"4 - Парсить user-name [{options[3].replace('\n', '')}]\n"
+        key = str(input((f"1 - Обновить api_id [{options[0].strip()}]\n"
+                         f"2 - Обновить api_hash [{options[1].strip()}]\n"
+                         f"3 - Парсить user-id [{options[2].strip()}]\n"
+                         f"4 - Парсить user-name [{options[3].strip()}]\n"
                          f"5 - Добавить аккаунт юзербота [{len(sessions)}]\n"
                           "6 - Сбросить настройки (.env)\n"
                           "e - Выход\n"


### PR DESCRIPTION
Replace `.replace('\n', '')` with `.strip()` in f-strings to resolve a `SyntaxError` caused by backslashes in f-string expressions.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eae10d1-f70b-432e-abbb-07d75db137d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0eae10d1-f70b-432e-abbb-07d75db137d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

