### PR TITLE
Fix callback event attribute error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -93,7 +93,7 @@ def main():
 			[Button.inline('Настройки', cb('CFG'))],
 		]
 		text = 'Выберите действие:'
-		if event.is_reply or isinstance(event, events.CallbackQuery.Event):
+		if isinstance(event, events.CallbackQuery.Event) or getattr(event, 'is_reply', False):
 			try:
 				await event.edit(text, buttons=buttons)
 			except Exception:


### PR DESCRIPTION
Fix `AttributeError` on `CallbackQuery.Event` by safely checking the `is_reply` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-1af59da4-fb71-4b79-9be6-5c8b72ee061b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1af59da4-fb71-4b79-9be6-5c8b72ee061b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

