### PR TITLE
Debug asyncio type error in telegram bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -76,7 +76,7 @@ def main():
 		sys.exit(1)
 
 	client = TelegramClient('bot_session', api_id, api_hash)
-	client.loop.run_until_complete(client.start(bot_token=bot_token))
+	client.start(bot_token=bot_token)
 
 	# Simple in-memory state for asking text input and filters
 	user_states: dict[int, dict] = {}


### PR DESCRIPTION
Fix `TypeError` by calling `client.start` synchronously.

The `client.start` method was being passed to `run_until_complete` but was not an awaitable, leading to a `TypeError`. This change aligns the call with the synchronous nature of `client.start` in this environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-88a348ae-467b-43b0-acba-2d98f94d8b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88a348ae-467b-43b0-acba-2d98f94d8b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

